### PR TITLE
Potential fix for code scanning alert no. 1: Use of insecure HostKeyCallback implementation

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -7,10 +7,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 type TunnelRequest struct {
@@ -179,10 +182,24 @@ func (m *manager) startTunnel(req TunnelRequest) error {
 		return fmt.Errorf("invalid private key: %w", err)
 	}
 
+	knownHostsPath := os.Getenv("SSH_KNOWN_HOSTS")
+	if knownHostsPath == "" {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return fmt.Errorf("failed to determine user home directory for known_hosts: %w", homeErr)
+		}
+		knownHostsPath = filepath.Join(home, ".ssh", "known_hosts")
+	}
+
+	hostKeyCallback, err := knownhosts.New(knownHostsPath)
+	if err != nil {
+		return fmt.Errorf("failed to initialize host key callback from %s: %w", knownHostsPath, err)
+	}
+
 	config := &ssh.ClientConfig{
 		User:            req.SSHUser,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         10 * time.Second,
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/hubfly-space/hubfly-cli/security/code-scanning/1](https://github.com/hubfly-space/hubfly-cli/security/code-scanning/1)

Use a secure `HostKeyCallback` that validates the SSH server key against a trusted allow-list. The best non-breaking approach here is to use OpenSSH-style `known_hosts` verification via `knownhosts.New(...)`, configured from a file path provided through environment variable (with a sensible default like `~/.ssh/known_hosts`), then assign that callback to `ClientConfig.HostKeyCallback`.

In `internal/service/service.go`:
- Update imports to include:
  - `os`
  - `path/filepath`
  - `golang.org/x/crypto/ssh/knownhosts`
- In `startTunnel`, before building `ssh.ClientConfig`, construct a secure callback:
  - Resolve known_hosts path (`SSH_KNOWN_HOSTS` env var, fallback to `$HOME/.ssh/known_hosts`)
  - Build callback with `knownhosts.New(...)`
  - Return an error if callback creation fails
- Replace `ssh.InsecureIgnoreHostKey()` with the secure callback variable.

This preserves existing SSH auth behavior and timeout while adding required host key validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - SSH connections now verify server host keys against a `known_hosts` file.
  - Supports a custom file location through `SSH_KNOWN_HOSTS`, with the standard SSH location used by default.
  - Connections fail safely if the host key configuration cannot be initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->